### PR TITLE
CI initial setup

### DIFF
--- a/.github/workflows/apisvr.yml
+++ b/.github/workflows/apisvr.yml
@@ -1,0 +1,58 @@
+# See https://help.github.com/en/actions/automating-your-workflow-with-github-actions
+
+name: apisvr CI
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - ".github/**"
+      - "apisvr/**"
+      - "containers/**"
+      - "dbmigrations/**"
+      - "*"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    # if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-go
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "apisvr/go.mod"
+
+      - name: Check docker version
+        run: |
+          set -x
+          docker -v
+          docker-compose -v
+          docker compose version
+          docker version
+
+      - name: Install firebase tools
+        run: npm install -g firebase-tools
+        working-directory: ./ui
+
+      - name: Check golang version/env
+        run: |
+          set -x
+          go version
+          go env
+
+      - name: build
+        run: make build
+        working-directory: ./apisvr
+
+      - name: lint
+        run: make lint
+        working-directory: ./apisvr
+
+      - name: test
+        run: make test
+        working-directory: ./apisvr

--- a/.github/workflows/apisvr.yml
+++ b/.github/workflows/apisvr.yml
@@ -56,3 +56,5 @@ jobs:
       - name: test
         run: make test
         working-directory: ./apisvr
+        env:
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,84 @@
+# See https://help.github.com/en/actions/automating-your-workflow-with-github-actions
+
+name: ui CI
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - ".github/**"
+      - "apisvr/**"
+      - "containers/**"
+      - "dbmigrations/**"
+      - "ui/**"
+      - "*"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    # if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+
+      # https://github.com/actions/setup-go
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "apisvr/go.mod"
+
+      - name: Check golang version/env
+        run: |
+          set -x
+          go version
+          go env
+
+      # https://github.com/actions/setup-node
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check node/yarn version
+        run: |
+          set -x
+          node -v
+          yarn -v
+          npm -v
+          npm prefix --location=global
+
+      - name: Check docker version
+        run: |
+          set -x
+          docker -v
+          docker-compose -v
+          docker compose version
+          docker version
+
+      - name: Install firebase tools
+        run: npm install -g firebase-tools
+        working-directory: ./ui
+
+      - name: npm install
+        run: npm install
+        working-directory: ./ui
+
+      - name: build
+        run: npm run build
+        working-directory: ./ui
+
+      - name: lint
+        run: npm run build
+        working-directory: ./ui
+
+      - name: unit test
+        run: npm run test:unit
+        working-directory: ./ui
+
+      - name: install playwright
+        run: npx playwright install
+        working-directory: ./ui
+
+      - name: integration test
+        run: npm run test:integration
+        working-directory: ./ui

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -60,15 +60,15 @@ jobs:
         working-directory: ./ui
 
       - name: npm install
-        run: npm install
+        run: make install
         working-directory: ./ui
 
       - name: build
-        run: npm run build
+        run: make build
         working-directory: ./ui
 
       - name: lint
-        run: npm run build
+        run: make lint
         working-directory: ./ui
 
       - name: unit test

--- a/apisvr/Makefile
+++ b/apisvr/Makefile
@@ -1,5 +1,5 @@
 .PHONY: default
-default: build test
+default: build lint test
 
 include ../config.mk
 include ./Makefiles/dev.mk

--- a/apisvr/Makefiles/lint.mk
+++ b/apisvr/Makefiles/lint.mk
@@ -1,4 +1,5 @@
 # https://github.com/golangci/golangci-lint
+# See https://golangci-lint.run/usage/false-positives/#nolint-directive for nolint directive
 LINT_GOLANGCI_LINT_VERSION=v1.55.2
 LINT_GOLANGCI_LINT=$(shell go env GOPATH)/bin/golangci-lint
 $(LINT_GOLANGCI_LINT):

--- a/apisvr/Makefiles/test.mk
+++ b/apisvr/Makefiles/test.mk
@@ -17,7 +17,7 @@ test: test_containers_up test_mysql_wait_to_connect test_dbmigration_up
 
 .PHONY: test_run
 test_run:
-	go test -tags timetravel ./...
+	go test -p 1 -tags timetravel ./...
 
 .PHONY: test_containers_up
 test_containers_up:

--- a/apisvr/design/app_local_dsl.go
+++ b/apisvr/design/app_local_dsl.go
@@ -8,8 +8,3 @@ func field(tag any, name string, args ...any) string {
 	dsl.Field(tag, name, args...)
 	return name
 }
-
-func gRPC() {
-	dsl.GRPC(func() {
-	})
-}

--- a/apisvr/design/auth.go
+++ b/apisvr/design/auth.go
@@ -2,9 +2,11 @@ package design
 
 import "goa.design/goa/v3/dsl"
 
+//nolint:unused
 const sessionIdScheme = "api_key"
 const sessionIdKey = "session_id"
 
+//nolint:unused
 var sessionAuth = dsl.APIKeySecurity(sessionIdScheme, func() {
 })
 

--- a/apisvr/design/errors.go
+++ b/apisvr/design/errors.go
@@ -19,10 +19,10 @@ func userError(key string, httpStatusCode int, grpcCode int) func() (func(), fun
 
 var (
 	unauthenticated = userError("unauthenticated", dsl.StatusUnauthorized, dsl.CodeUnauthenticated)
-	unauthorized    = userError("unauthorized", dsl.StatusForbidden, dsl.CodePermissionDenied)
+	unauthorized    = userError("unauthorized", dsl.StatusForbidden, dsl.CodePermissionDenied) //nolint:unused
 	notFound        = userError("not_found", dsl.StatusNotFound, dsl.CodeNotFound)
-	invalidQuery    = userError("invalid_query", dsl.StatusBadRequest, dsl.CodeInvalidArgument)
+	invalidQuery    = userError("invalid_query", dsl.StatusBadRequest, dsl.CodeInvalidArgument) //nolint:unused
 	invalidPayload  = userError("invalid_payload", dsl.StatusBadRequest, dsl.CodeInvalidArgument)
-	conflict        = userError("conflict", dsl.StatusConflict, dsl.CodeAlreadyExists)
-	paymentRequired = userError("payment_required", dsl.StatusPaymentRequired, dsl.CodeFailedPrecondition)
+	conflict        = userError("conflict", dsl.StatusConflict, dsl.CodeAlreadyExists)                     //nolint:unused
+	paymentRequired = userError("payment_required", dsl.StatusPaymentRequired, dsl.CodeFailedPrecondition) //nolint:unused
 )

--- a/apisvr/lib/errors/aliases.go
+++ b/apisvr/lib/errors/aliases.go
@@ -1,10 +1,14 @@
 package errors
 
 import (
+	std "errors"
+
 	orig "github.com/friendsofgo/errors"
 )
 
 var (
+	Join = std.Join
+
 	// As        = orig.As
 	Cause  = orig.Cause
 	Is     = orig.Is

--- a/apisvr/lib/firebase/auth/factory.go
+++ b/apisvr/lib/firebase/auth/factory.go
@@ -25,6 +25,7 @@ func NewClientWithLogger(ctx context.Context, app *firebase.App, logger *log.Log
 
 type ClientFactoryFunc = func(ctx context.Context, app *firebase.App, logger *log.Logger) (Client, error)
 
+//nolint:unused
 var clientFactory ClientFactoryFunc = func(ctx context.Context, app *firebase.App, logger *log.Logger) (Client, error) {
 	cli, err := NewClientWithLogger(ctx, app, logger)
 	if err != nil {

--- a/apisvr/lib/sql/tx.go
+++ b/apisvr/lib/sql/tx.go
@@ -1,6 +1,9 @@
 package sql
 
-import "context"
+import (
+	"apisvr/lib/errors"
+	"context"
+)
 
 func BeginTx(ctx context.Context, db *DB, cb func(context.Context, *Tx) error) error {
 	tx, err := db.BeginTx(ctx, nil)
@@ -9,7 +12,9 @@ func BeginTx(ctx context.Context, db *DB, cb func(context.Context, *Tx) error) e
 	}
 
 	if err := cb(ctx, tx); err != nil {
-		tx.Rollback()
+		if rollbackError := tx.Rollback(); rollbackError != nil {
+			return errors.Join(err, errors.Wrapf(rollbackError, "rollback error"))
+		}
 		return err
 	}
 

--- a/apisvr/lib/time/location.go
+++ b/apisvr/lib/time/location.go
@@ -1,0 +1,9 @@
+package time
+
+var defaultLocation = func() *Location {
+	loc, err := LoadLocation("Asia/Tokyo")
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}()

--- a/apisvr/lib/time/now.go
+++ b/apisvr/lib/time/now.go
@@ -3,5 +3,13 @@ package time
 import orig "time"
 
 func Now() orig.Time {
+	return LocalNow()
+}
+
+func LocalNow() orig.Time {
+	return nowFunc().In(defaultLocation)
+}
+
+func DefaultNow() orig.Time {
 	return nowFunc()
 }

--- a/apisvr/services/users.go
+++ b/apisvr/services/users.go
@@ -67,7 +67,7 @@ func (s *userssrvc) Create(ctx context.Context, p *users.UserCreatePayload) (res
 			return err
 		}
 
-		err = sql.BeginTx(ctx, db, func(ctx context.Context, tx *sql.Tx) error {
+		return sql.BeginTx(ctx, db, func(ctx context.Context, tx *sql.Tx) error {
 			if m, err := models.Users(qm.Where("email = ?", p.Email)).One(ctx, db); err != nil {
 				if err == sql.ErrNoRows {
 					// OK
@@ -131,7 +131,6 @@ func (s *userssrvc) Create(ctx context.Context, p *users.UserCreatePayload) (res
 			res = s.ModelToResult(m)
 			return nil
 		})
-		return nil
 	})
 	return
 }

--- a/apisvr/testlib/testgoogle/testidentitytoolkit/id_token.go
+++ b/apisvr/testlib/testgoogle/testidentitytoolkit/id_token.go
@@ -29,7 +29,7 @@ func GetIdToken(t testing.TB, ctx context.Context, email, password string, opts 
 		}
 	}
 	// option.WithEndpoint("http://localhost:9099/identitytoolkit.googleapis.com/v1"),
-	// option.WithAPIKey("AIzaSyBRcOfsczLRC7VX0iirMU2dlAFKYPRo-9U"),
+	// option.WithAPIKey("[firebaseConfig.apiKey]"),
 	identitytoolkitService, err := identitytoolkit.NewService(ctx, opts...)
 	if err != nil {
 		t.Fatal(err)

--- a/ui/.eslintignore
+++ b/ui/.eslintignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+/src/lib/server/protos

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+/src/lib/server/protos

--- a/ui/.prettierrc
+++ b/ui/.prettierrc
@@ -3,7 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-tailwindcss"],
+	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"overrides": [
 		{
 			"files": "*.svelte",

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -9,3 +9,7 @@ dev:
 .PHONY: preview
 preview:
 	npm run preview
+
+.PHONY: test
+test:
+	npm run test

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,15 +1,31 @@
+NODE_MODULES=node_modules
+$(NODE_MODULES):
+	$(MAKE) install
+
+.PHONY: install
+install:
+	npm install
+
 .PHONY: build
-build:
+build: setup
 	npm run build
 
 .PHONY: dev
-dev:
+dev: setup
 	npm run dev
 
 .PHONY: preview
-preview:
+preview: setup
 	npm run preview
 
 .PHONY: test
 test:
 	npm run test
+
+.PHONY: setup
+setup: $(NODE_MODULES) 
+	$(MAKE) $(FIREBASE_CONFIG_FILE)
+
+FIREBASE_CONFIG_FILE=src/lib/firebase/firebaseconfig.ts
+$(FIREBASE_CONFIG_FILE):
+	cp $(FIREBASE_CONFIG_FILE).dummy $(FIREBASE_CONFIG_FILE)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -10,6 +10,10 @@ install:
 build: setup
 	npm run build
 
+.PHONY: lint
+lint:
+	npm run lint
+
 .PHONY: dev
 dev: setup
 	npm run dev

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,7 @@
 		"grpc:gen:channels": "mkdir -p src/lib/server/protos && protoc --ts_out $_ --proto_path ../apisvr/services/gen/grpc/channels/pb ../apisvr/services/gen/grpc/channels/pb/goagen_services_channels.proto",
 		"grpc:gen:users": "mkdir -p src/lib/server/protos && protoc --ts_out $_ --proto_path ../apisvr/services/gen/grpc/users/pb ../apisvr/services/gen/grpc/users/pb/goagen_services_users.proto",
 		"grpc:gen:chat_messages": "mkdir -p src/lib/server/protos && protoc --ts_out $_ --proto_path ../apisvr/services/gen/grpc/chat_messages/pb ../apisvr/services/gen/grpc/chat_messages/pb/goagen_services_chat_messages.proto",
-		"test": "run-s test:unit test:integration",
+		"test": "run-s test:unit:run test:integration",
 		"test:integration": "run-s test:integration:setup test:integration:run",
 		"test:integration:containers:up": "make -C tests/integration/containers up",
 		"test:integration:containers:down": "make -C tests/integration/containers down",
@@ -27,7 +27,9 @@
 		"test:integration:run": "playwright test tests/integration/test.ts",
 		"test:integration:setup": "run-s test:integration:containers:restart test:integration:dbmigrattions:up",
 		"test:integration:teardown": "npm run test:integration:containers:down",
-		"test:unit": "vitest"
+		"test:unit": "vitest",
+		"test:unit:run": "vitest run",
+		"test:unit:watch": "vitest watch"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.40.1",

--- a/ui/src/lib/firebase/firebaseconfig.ts.dummy
+++ b/ui/src/lib/firebase/firebaseconfig.ts.dummy
@@ -1,0 +1,10 @@
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+export const firebaseConfig = {
+	apiKey: 'dummy-firebase-api-key1',
+	authDomain: 'sk-goa-chat-app1.firebaseapp.com',
+	projectId: 'sk-goa-chat-app1',
+	storageBucket: 'sk-goa-chat-app1.appspot.com',
+	messagingSenderId: '012345678901',
+	appId: '1:012345678901:web:0123456789abcdefghijkl',
+	measurementId: 'G-ZZZZZZZZZZ'
+};

--- a/ui/src/routes/(app)/channels/[id]/+page.svelte
+++ b/ui/src/routes/(app)/channels/[id]/+page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import { Heading, TextPlaceholder, Alert } from 'flowbite-svelte';
+	import { Heading, Alert } from 'flowbite-svelte';
 	import { Button, Modal, Label, Input, Hr } from 'flowbite-svelte';
 	import { CogOutline, TrashBinSolid, InfoCircleSolid } from 'flowbite-svelte-icons';
 
 	import type { Channel } from '$lib/models/channel';
 	import type { ChatMessage } from '$lib/models/chat_message';
-	import { channelOptionsEqual } from '@grpc/grpc-js/build/src/channel-options.js';
 	import { notificationsSocket } from '$lib/websockets';
 	import { onDestroy, onMount } from 'svelte';
 
@@ -139,7 +138,7 @@
 			scrollContainer.scrollHeight - (scrollContainer.scrollTop + scrollContainer.clientHeight);
 		return pos < 100;
 	};
-	const scrollToLatestChat = (behavior?: ScrollBehavior) => {
+	const scrollToLatestChat = (behavior?: 'instant' | 'smooth') => {
 		scrollContainer.scrollTo({
 			top: scrollContainer.scrollHeight - scrollContainer.clientHeight - 50,
 			behavior: behavior

--- a/ui/src/routes/(public)/signin/+page.svelte
+++ b/ui/src/routes/(public)/signin/+page.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
 	import { createSession } from '$lib/session';
-	import { app, isFirebaseError } from '$lib/firebase';
+	import { isFirebaseError } from '$lib/firebase';
 	import { auth } from '$lib/firebase/auth';
 	import { page } from '$app/stores';
 
 	import { onMount } from 'svelte';
-	import { getAnalytics } from 'firebase/analytics';
 	import { signInWithEmailAndPassword, type UserCredential } from 'firebase/auth';
 
 	import { Label, Input, Button, Heading } from 'flowbite-svelte';
 	import { ExclamationCircleOutline } from 'flowbite-svelte-icons';
 
 	onMount(() => {
-		const analytics = getAnalytics(app);
+		// const analytics = getAnalytics(app);
 	});
 	let email = '';
 	let password = '';

--- a/ui/src/routes/(public)/signup/+page.svelte
+++ b/ui/src/routes/(public)/signup/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-	import { app, isFirebaseError } from '$lib/firebase';
+	import { isFirebaseError } from '$lib/firebase';
 	import { auth } from '$lib/firebase/auth';
 	import { createSession } from '$lib/session';
 	import { page } from '$app/stores';
 
-	import { getAnalytics } from 'firebase/analytics';
 	import {
 		type UserCredential,
 		createUserWithEmailAndPassword,
@@ -17,7 +16,7 @@
 
 	onMount(() => {
 		// analytics の初期化は onMount の外で実行すると  window is not defined というエラーが firebase の内部
-		const analytics = getAnalytics(app);
+		// const analytics = getAnalytics(app);
 	});
 
 	let email = '';

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -34,7 +34,7 @@
 </script>
 
 <div class="flex h-full w-full flex-row overflow-x-hidden">
-	<div class="flex w-64 flex-shrink-0 flex-col bg-white py-2 pl-6 pr-2">
+	<div class="flex w-64 flex-shrink-0 flex-col bg-white py-2 pl-6 pr-2" data-testid="sidebar">
 		<div class="flex flex-auto flex-shrink-0 flex-col rounded-2xl p-4">
 			<div class="flex flex-row mb-4">
 				<div class="flex-none w-12">

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -38,12 +38,16 @@
 		<div class="flex flex-auto flex-shrink-0 flex-col rounded-2xl p-4">
 			<div class="flex flex-row mb-4">
 				<div class="flex-none w-12">
-					<img src="/logo192.png" class="mr-3 h-6 sm:h-9" alt="SK Goa Chat Logo" />
+					<a href="/">
+						<img src="/logo192.png" class="mr-3 h-6 sm:h-9" alt="SK Goa Chat Logo" />
+					</a>
 				</div>
 				<div class="flex-shrink pt-1">
-					<span class="self-center whitespace-nowrap text-xl font-semibold dark:text-white">
-						SK Goa Chat
-					</span>
+					<a href="/">
+						<span class="self-center whitespace-nowrap text-xl font-semibold dark:text-white">
+							SK Goa Chat
+						</span>
+					</a>
 				</div>
 			</div>
 		</div>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { TextPlaceholder } from 'flowbite-svelte';
 </script>
 
 <div>

--- a/ui/tests/integration/test.ts
+++ b/ui/tests/integration/test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
-import { Header } from '../materials/panes/header';
+import { Sidebar } from '../materials/panes/sidebar';
 import { SigninPage } from '../materials/pages/signin_page';
 import { SignupPage } from '../materials/pages/signup_page';
 
 test('show signin page when go to root', async ({ page }) => {
-	const header = new Header(page);
+	const header = new Sidebar(page);
 	const signinPage = new SigninPage(page);
 	const signupPage = new SignupPage(page);
 

--- a/ui/tests/materials/panes/sidebar.ts
+++ b/ui/tests/materials/panes/sidebar.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-export class Header {
+export class Sidebar {
 	readonly locator: Locator;
 	constructor(page: Page) {
 		this.locator = page.locator('nav[data-testid="header_nav"]');

--- a/ui/tests/materials/panes/sidebar.ts
+++ b/ui/tests/materials/panes/sidebar.ts
@@ -16,13 +16,9 @@ export class Sidebar {
 
 	get avatarMenu(): AvatarMenu {
 		return new AvatarMenu(
-			this.locator.locator('div[role="tooltip"]:has(span[data-testid="account_name"])')
+			this.locator.locator('div[role="tooltip"]:has(button:text("ログアウト"))')
 		);
 	}
-}
-
-export class AvatarMenu {
-	constructor(readonly locator: Locator) {}
 
 	get accountName(): Locator {
 		return this.locator.locator('span[data-testid="account_name"]');
@@ -30,6 +26,10 @@ export class AvatarMenu {
 	get accountEmail(): Locator {
 		return this.locator.locator('span[data-testid="account_email"]');
 	}
+}
+
+export class AvatarMenu {
+	constructor(readonly locator: Locator) {}
 
 	get signoutButton(): Locator {
 		return this.locator.locator('button:text("ログアウト")');

--- a/ui/tests/materials/panes/sidebar.ts
+++ b/ui/tests/materials/panes/sidebar.ts
@@ -3,7 +3,7 @@ import type { Locator, Page } from '@playwright/test';
 export class Sidebar {
 	readonly locator: Locator;
 	constructor(page: Page) {
-		this.locator = page.locator('nav[data-testid="header_nav"]');
+		this.locator = page.locator('div[data-testid="sidebar"]');
 	}
 
 	get title(): Locator {


### PR DESCRIPTION
GitHub Actions Workflow でCIを動かす設定を追加

- CI を実行するに当たって リポジトリを public に
    - [GitGuardian](https://www.gitguardian.com/) が検出したGoogle の API Key を revoke  https://github.com/akm/sk-goa-chat/pull/31/commits/1405b6d5ff888f4c533397bd0ceb95bd0c91496c
- apisvr 
    - テストが失敗するので 並列で実行するテストのプロセスを1に限定
    - lint を make のデフォルトで動かすように
    - lint の指摘に対応
        - 使われていないコードを削除、あるいはlintの対象外に設定
        - ハンドリングされていないerrorに対応
            - errors.Join でerror を統合できるように
        - GitHub Actions上では 日付のロケーションがUTC であったため失敗していたテストを修正
            - `apisvr/lib/time` の Now は `Asia/Tokyo` のロケーションの time.Time を返すように変更
- ui
    - src/lib/server/protos は eslint/prettier 対象外に
    - make build, dev  で自動的にインストールや必要なファイルを生成
        - CIで使用するfirebaseconfig.ts は ダミーのファイルを必要に応じて生成
    - Playwright でのテストがパスするように #29 に対応した変更を ui/tests 以下に反映
    - lint で指摘された不要なものを削除
