### PR TITLE
time パッケージについては go.mod での replace ではなく import を置き換えるように修正

### DIFF
--- a/backend/biz/.vscode/launch.json
+++ b/backend/biz/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run test",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}",
+      "env": {
+        "APP_STAGE": "local",
+        "APP_ENV": "unit_test",
+        "APP_MYSQL_PORT": "3311",
+        "APP_MYSQL_DSN": "root:@tcp(127.0.0.1:3311)/sk_goa_chat_db?charset=utf8mb4&parseTime=True&loc=Asia%2FTokyo",
+        "MYSQL_PORT": "3311",
+        "GOOGLE_CLOUD_PROJECT": "sk-goa-chat",
+        "FIREBASE_AUTH_EMULATOR_HOST": "127.0.0.1:9091"
+      },
+      "args": ["-test.v"],
+      "buildFlags": "-tags timetravel",
+      "showLog": true
+    }
+  ]
+}

--- a/backend/biz/Makefiles/sqlboiler.mk
+++ b/backend/biz/Makefiles/sqlboiler.mk
@@ -1,6 +1,7 @@
 .PHONY: sqlboiler_gen
 sqlboiler_gen: sqlboiler_gen_prepare
-	sqlboiler mysql
+	sqlboiler mysql && \
+	$(MAKE) -C ../../modifiers backend_biz_models
 
 .PHONY: sqlboiler_gen_prepare
 sqlboiler_gen_prepare:

--- a/backend/biz/Makefiles/sqlboiler.mk
+++ b/backend/biz/Makefiles/sqlboiler.mk
@@ -5,4 +5,6 @@ sqlboiler_gen: sqlboiler_gen_prepare
 
 .PHONY: sqlboiler_gen_prepare
 sqlboiler_gen_prepare:
-	$(MAKE) -C ../dbmigrations up
+	$(MAKE) -C ../containers/localdev up && \
+	$(MAKE) -C ../containers/mysql wait_to_connect && \
+	APP_SKIP_DB_SCHEMA_DUMP=true $(MAKE) -C ../dbmigrations up

--- a/backend/biz/go.mod
+++ b/backend/biz/go.mod
@@ -4,8 +4,6 @@ go 1.21.4
 
 replace applib => ../applib
 
-replace time => ../applib/time
-
 require (
 	applib v0.0.0-00010101000000-000000000000
 	github.com/friendsofgo/errors v0.9.2

--- a/backend/biz/models/boil_main_test.go
+++ b/backend/biz/models/boil_main_test.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"applib/time"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/viper"
 	"github.com/volatiletech/sqlboiler/v4/boil"

--- a/backend/biz/models/channels.go
+++ b/backend/biz/models/channels.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"applib/time"
 	"context"
 	"database/sql"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/v4/boil"

--- a/backend/biz/models/chat_messages.go
+++ b/backend/biz/models/chat_messages.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"applib/time"
 	"context"
 	"database/sql"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/null/v8"

--- a/backend/biz/models/goose_db_version.go
+++ b/backend/biz/models/goose_db_version.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"applib/time"
 	"context"
 	"database/sql"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/null/v8"

--- a/backend/biz/models/users.go
+++ b/backend/biz/models/users.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"applib/time"
 	"context"
 	"database/sql"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/v4/boil"

--- a/modifiers/Makefile
+++ b/modifiers/Makefile
@@ -7,6 +7,14 @@ backend_apisvr_services_cmd:
 	FILE=backend/apisvr/services/cmd/apisvr/main.go $(MAKE) single && \
 	FILE=backend/apisvr/services/cmd/apisvr/http.go $(MAKE) single
 
+.PHONY: backend_biz_models
+backend_biz_models:
+	PATTERN=backend/biz/models/models.rb $(MAKE) match
+
 .PHONY: single
 single:
 	ruby ./single.rb ../${FILE}
+
+.PHONY: match
+match:
+	ruby ./match.rb ./${PATTERN}

--- a/modifiers/backend/biz/models/models.rb
+++ b/modifiers/backend/biz/models/models.rb
@@ -1,0 +1,1 @@
+$content.sub!('"time"'){|key| '"applib/time"' }

--- a/modifiers/match.rb
+++ b/modifiers/match.rb
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+pattern_path = ARGV.shift
+if pattern_path.nil? || pattern_path.empty?
+    puts "usage: ruby #{__FILE__} <pattern_path>"
+    exit(1)
+end
+
+root_path = File.expand_path('../..', __FILE__)
+parent_path = File.dirname(pattern_path)
+target_pattern = File.join(root_path, parent_path, '**/*.go')
+
+target_paths = Dir.glob(target_pattern)
+target_paths.each do |target_path|
+    $target_path = target_path
+    $content = File.read(target_path)
+    load(pattern_path) # パターンを読み込む
+    open(target_path, 'w'){|f| f.puts($content) }
+    system("go fmt #{target_path}", exception: true)
+end


### PR DESCRIPTION
- go.mod で `time` を `applib/time` に replace できたかと思ったのですが、調べてみると https://github.com/golang/go/issues/35283 で却下されているようですし、実際デバッガで試してみても期待した動きはしていませんでした。
- なので、 go.mod から replace を削除し、地道に `"time"` の import を `"applib/time"` に置換するように modifiers を追加しました
- 今回は不特定の数のファイルを置換する match.rb を追加しました