### PR TITLE
初回のルートの make test を成功するように playwright install を自動で実行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ lint:
 .PHONY: test
 test:
 	$(MAKE) -C backend test && \
+	$(MAKE) -C frontend test_integration_pw_setup && \
 	$(MAKE) -C frontend test
 
 .PHONY: dev

--- a/frontend/Makefiles/test_integration.mk
+++ b/frontend/Makefiles/test_integration.mk
@@ -31,3 +31,11 @@ test_integration_dbmigrations_up:
 .PHONY: test_integration_setup
 test_integration_setup:
 	$(MAKE) -C tests/integration test_setup
+
+# このターゲットは、playwright のセットアップを行うためのものです。
+# 実行すると最新の　playwright のブラウザがインストールされて時間がかかるので、
+# test_integration_setup　には含めません。
+.PHONY: test_integration_pw_setup
+test_integration_pw_setup:
+	npx playwright install
+


### PR DESCRIPTION
タイトルの通りです。

frontend の test_integration の実行にはplaywrightの使うブラウザをインストールするために npx playwright install を実行する必要があります。

そのためのターゲット test_integration_pw_setup を追加しました。

しかし make tes_integration の依存に追加すると、テストを実行するたびに最新のブラウザをインストールしようと指定しまうので、ルートの make test でのみ test_integration_pw_setup を呼び出すようにしました。
