### PR TITLE
DBへの接続をサービスのメソッド内ではなくその外側のエンドポイントで行うように変更

### DIFF
--- a/backend/apisvr/services/base.go
+++ b/backend/apisvr/services/base.go
@@ -29,10 +29,6 @@ func newBaseService(logger *log.Logger) baseService {
 	return baseService{logger: logger}
 }
 
-func (s *baseService) sqlOpen() (*sql.DB, error) {
-	return sql.Open(s.logger.Logger)
-}
-
 func (s *baseService) action(ctx context.Context, name string, cb func(context.Context) error) error {
 	s.logger.Info().Msg(name)
 	return cb(SetupContext(ctx))

--- a/backend/apisvr/services/base.go
+++ b/backend/apisvr/services/base.go
@@ -8,13 +8,13 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	goa "goa.design/goa/v3/pkg"
 
+	log "apisvr/services/gen/log"
+	"applib/database/sql"
 	"applib/errors"
 	"applib/firebase"
 	"applib/firebase/auth"
-	"applib/database/sql"
 	"biz/models"
 	_ "biz/models_ext"
-	log "apisvr/services/gen/log"
 )
 
 func SetupContext(ctx context.Context) context.Context {
@@ -41,11 +41,10 @@ func (s *baseService) action(ctx context.Context, name string, cb func(context.C
 func (s *baseService) actionWithDB(ctx context.Context, name string, cb func(context.Context, *sql.DB) error) error {
 	s.logger.Info().Msg(name)
 	ctx = SetupContext(ctx)
-	db, err := s.sqlOpen()
+	db, err := sql.ConnectionFromContext(ctx)
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 	return cb(ctx, db)
 }
 

--- a/backend/apisvr/services/channels_test.go
+++ b/backend/apisvr/services/channels_test.go
@@ -29,7 +29,7 @@ func TestChannels(t *testing.T) {
 	now := time.Now()
 	defer timetest.SetNow(now)
 
-	ctx := context.Background()
+	ctx := sql.NewContextWithConnection(context.Background(), conn)
 	srvc := NewChannels(&log.Logger{Logger: logger})
 	conv := NewChannelsConvertor()
 

--- a/backend/apisvr/services/chat_messages_test.go
+++ b/backend/apisvr/services/chat_messages_test.go
@@ -4,6 +4,7 @@ import (
 	chatmessages "apisvr/services/gen/chat_messages"
 	log "apisvr/services/gen/log"
 	"applib/collection"
+	"applib/database/sql"
 	"applib/database/sql/sqltest"
 	"applib/firebase/auth/authtest"
 	"applib/goa/goatest"
@@ -32,7 +33,7 @@ func TestChaeMessages(t *testing.T) {
 	now := time.Now()
 	defer timetest.SetNow(now)
 
-	ctx := context.Background()
+	ctx := sql.NewContextWithConnection(context.Background(), conn)
 	srvc := NewChatMessages(&log.Logger{Logger: logger})
 	conv := NewChatMessageConvertor()
 
@@ -148,7 +149,7 @@ func TestChaeMessagesList(t *testing.T) {
 	now := time.Now()
 	defer timetest.SetNow(now)
 
-	ctx := context.Background()
+	ctx := sql.NewContextWithConnection(context.Background(), conn)
 	srvc := NewChatMessages(&log.Logger{Logger: logger})
 	conv := NewChatMessageConvertor()
 

--- a/backend/apisvr/services/tests/grpc_integrations/channels_test.go
+++ b/backend/apisvr/services/tests/grpc_integrations/channels_test.go
@@ -9,6 +9,8 @@ import (
 	"applib/database/sql/sqltest"
 	"applib/encoding/json/jsontest"
 	"applib/firebase/auth/authtest"
+	goaendpoints "applib/goa/endpoints"
+	"applib/goa/goasql"
 	"applib/log/logtest"
 	"applib/sqlboiler/sqlboilertest"
 	"applib/time"
@@ -171,8 +173,9 @@ func setupChannelsServer(ctx context.Context, logger *log.Logger) (channelspb.Ch
 			grpcmdlwr.UnaryServerLog(adapter),
 		),
 	)
+	epWrapper := goasql.ConnectionEndpointWrapper(logger.Logger)
 	channelsSvc := chatapi.NewChannels(logger)
-	channelsEndpoints := channels.NewEndpoints(channelsSvc)
+	channelsEndpoints := goaendpoints.Wrap[*channels.Endpoints](channels.NewEndpoints(channelsSvc), epWrapper)
 	channelsServer := channelssvr.New(channelsEndpoints, nil)
 	channelspb.RegisterChannelsServer(srv, channelsServer)
 

--- a/backend/apisvr/services/tests/http_integrations/channels_test.go
+++ b/backend/apisvr/services/tests/http_integrations/channels_test.go
@@ -8,6 +8,7 @@ import (
 	"applib/database/sql/sqltest"
 	"applib/encoding/json/jsontest"
 	"applib/firebase/auth/authtest"
+	"applib/goa/goasql"
 	"applib/goa/goatest"
 	"applib/log/logtest"
 	"applib/sqlboiler/sqlboilertest"
@@ -38,12 +39,14 @@ func TestChannels(t *testing.T) {
 	srvc := chatapi.NewChannels(&log.Logger{Logger: logger})
 	conv := chatapi.NewChannelsConvertor()
 
+	epWrapper := goasql.ConnectionEndpointWrapper(logger)
+
 	checker := goahttpcheck.New()
-	checker.Mount(server.NewListHandler, server.MountListHandler, channels.NewListEndpoint(srvc))
-	checker.Mount(server.NewShowHandler, server.MountShowHandler, channels.NewShowEndpoint(srvc))
-	checker.Mount(server.NewCreateHandler, server.MountCreateHandler, channels.NewCreateEndpoint(srvc))
-	checker.Mount(server.NewUpdateHandler, server.MountUpdateHandler, channels.NewUpdateEndpoint(srvc))
-	checker.Mount(server.NewDeleteHandler, server.MountDeleteHandler, channels.NewDeleteEndpoint(srvc))
+	checker.Mount(server.NewListHandler, server.MountListHandler, epWrapper(channels.NewListEndpoint(srvc)))
+	checker.Mount(server.NewShowHandler, server.MountShowHandler, epWrapper(channels.NewShowEndpoint(srvc)))
+	checker.Mount(server.NewCreateHandler, server.MountCreateHandler, epWrapper(channels.NewCreateEndpoint(srvc)))
+	checker.Mount(server.NewUpdateHandler, server.MountUpdateHandler, epWrapper(channels.NewUpdateEndpoint(srvc)))
+	checker.Mount(server.NewDeleteHandler, server.MountDeleteHandler, epWrapper(channels.NewDeleteEndpoint(srvc)))
 
 	fbauth := authtest.Setup(t, ctx)
 

--- a/backend/apisvr/services/tests/http_integrations/signup_test.go
+++ b/backend/apisvr/services/tests/http_integrations/signup_test.go
@@ -13,6 +13,7 @@ import (
 	"applib/firebase"
 	"applib/firebase/auth"
 	"applib/firebase/auth/authtest"
+	"applib/goa/goasql"
 	"applib/google/identitytoolkit/identitytoolkittest"
 	"applib/log/logtest"
 	"applib/time"
@@ -48,14 +49,16 @@ func TestSignup(t *testing.T) {
 		authtest.DeleteUsers(t, ctx, fbauth)
 	})
 
+	epWrapper := goasql.ConnectionEndpointWrapper(logger)
+
 	checker := goahttpcheck.New()
 	// checker.Mount(usersServer.NewListHandler, server.MountListHandler, channels.NewListEndpoint(srvc))
 	usersSrvc := chatapi.NewUsers(&log.Logger{Logger: logger})
-	checker.Mount(usersserver.NewCreateHandler, usersserver.MountCreateHandler, users.NewCreateEndpoint(usersSrvc))
+	checker.Mount(usersserver.NewCreateHandler, usersserver.MountCreateHandler, epWrapper(users.NewCreateEndpoint(usersSrvc)))
 
 	sessionSrvc := chatapi.NewSessions(&log.Logger{Logger: logger})
-	checker.Mount(sessionsserver.NewCreateHandler, sessionsserver.MountCreateHandler, sessions.NewCreateEndpoint(sessionSrvc))
-	checker.Mount(sessionsserver.NewDeleteHandler, sessionsserver.MountDeleteHandler, sessions.NewDeleteEndpoint(sessionSrvc))
+	checker.Mount(sessionsserver.NewCreateHandler, sessionsserver.MountCreateHandler, epWrapper(sessions.NewCreateEndpoint(sessionSrvc)))
+	checker.Mount(sessionsserver.NewDeleteHandler, sessionsserver.MountDeleteHandler, epWrapper(sessions.NewDeleteEndpoint(sessionSrvc)))
 
 	fooEmail := "foo@example.com"
 	fooName := "Foo"

--- a/backend/apisvr/services/users_test.go
+++ b/backend/apisvr/services/users_test.go
@@ -3,6 +3,7 @@ package chatapi
 import (
 	log "apisvr/services/gen/log"
 	"apisvr/services/gen/users"
+	"applib/database/sql"
 	"applib/database/sql/sqltest"
 	"applib/log/logtest"
 	"applib/sqlboiler/sqlboilertest"
@@ -24,7 +25,7 @@ func TestUsers(t *testing.T) {
 	now := time.Now()
 	defer timetest.SetNow(now)
 
-	ctx := context.Background()
+	ctx := sql.NewContextWithConnection(context.Background(), conn)
 	srvc := NewUsers(&log.Logger{Logger: logger})
 	conv := NewUsersConvertor()
 

--- a/backend/applib/database/sql/context.go
+++ b/backend/applib/database/sql/context.go
@@ -1,0 +1,24 @@
+package sql
+
+import (
+	"context"
+	"errors"
+)
+
+type contextConnectionKey string
+
+const ContextConnectionKey contextConnectionKey = "sql-connection"
+
+func NewContextWithConnection(ctx context.Context, db *DB) context.Context {
+	return context.WithValue(ctx, ContextConnectionKey, db)
+}
+
+var ErrNoConnectionInContext = errors.New("no connection in context")
+
+func ConnectionFromContext(ctx context.Context) (*DB, error) {
+	conn, ok := ctx.Value(ContextConnectionKey).(*DB)
+	if !ok {
+		return nil, ErrNoConnectionInContext
+	}
+	return conn, nil
+}

--- a/backend/applib/goa/endpoints/error_handler.go
+++ b/backend/applib/goa/endpoints/error_handler.go
@@ -1,0 +1,19 @@
+package goaendpoints
+
+import (
+	"context"
+
+	goa "goa.design/goa/v3/pkg"
+)
+
+func ErrorHandler(eh func(error) error) func(goa.Endpoint) goa.Endpoint {
+	return func(ep goa.Endpoint) goa.Endpoint {
+		return func(ctx context.Context, req any) (any, error) {
+			r, err := ep(ctx, req)
+			if err != nil {
+				err = eh(err)
+			}
+			return r, err
+		}
+	}
+}

--- a/backend/applib/goa/endpoints/wrap.go
+++ b/backend/applib/goa/endpoints/wrap.go
@@ -1,0 +1,40 @@
+package goaendpoints
+
+import (
+	"fmt"
+	"reflect"
+
+	goa "goa.design/goa/v3/pkg"
+)
+
+// Wrap は endpoints で指定された struct の各フィールドのうち goa.Endpoint 型のフィールドに対して、
+// エラーハンドラ eh を適用した関数を作成します。
+// 戻り値は、元の endpoints と同じ型の struct で、 eh が適用された goa.Endpoint 型のフィールドを持ちます。
+//
+// この関数は reflect を使用しますが、サーバー起動時にのみ使用され、リクエスト処理時には使用されません。
+// サーバー起動も著しく遅くなることはないので reflect を使っても問題ないと判断しました。
+func Wrap[Endpoints any](endpoints Endpoints, wrapper func(goa.Endpoint) goa.Endpoint) Endpoints {
+	srcVal := reflect.ValueOf(endpoints).Elem() // ポインタ
+	fmt.Printf("srcVal: [%T] %+v\n", srcVal.Interface(), srcVal.Interface())
+	dstVal := reflect.New(srcVal.Type()).Elem() // 同じ型のstructを作成。New はポインタのValueを返すので Elem を使う
+	fmt.Printf("dstVal: [%T] %+v\n", dstVal.Interface(), dstVal.Interface())
+
+	fieldNum := srcVal.NumField()
+	for i := 0; i < fieldNum; i++ {
+		field := srcVal.Field(i)
+		if field.Kind() != reflect.Func {
+			continue
+		}
+		fv := field.Interface()
+		fn, ok := fv.(goa.Endpoint)
+		if !ok {
+			continue
+		}
+		var dstFunc goa.Endpoint = wrapper(fn)
+		// dstField := dstVal.FieldByName(field.Name)
+		dstField := dstVal.Field(i)
+		dstField.Set(reflect.ValueOf(dstFunc))
+	}
+
+	return dstVal.Addr().Interface().(Endpoints)
+}

--- a/backend/applib/goa/endpoints/wrappers.go
+++ b/backend/applib/goa/endpoints/wrappers.go
@@ -1,0 +1,13 @@
+package goaendpoints
+
+import goa "goa.design/goa/v3/pkg"
+
+type Wrappers []func(goa.Endpoint) goa.Endpoint
+
+func (s Wrappers) Wrap(ep goa.Endpoint) goa.Endpoint {
+	r := ep
+	for _, w := range s {
+		r = w(r)
+	}
+	return r
+}

--- a/backend/applib/goa/goaext/error_handled_endpoints.go
+++ b/backend/applib/goa/goaext/error_handled_endpoints.go
@@ -1,47 +1,9 @@
 package goaext
 
 import (
-	"context"
-	"fmt"
-	"reflect"
-
-	goa "goa.design/goa/v3/pkg"
+	goaendpoints "applib/goa/endpoints"
 )
 
-// ErrorHandledEndpoints は endpoints で指定された struct の各フィールドのうち
-// goa.Endpoint 型のフィールドに対して、エラーハンドラ eh を適用した関数を作成します。
-// 戻り値は、元の endpoints と同じ型の struct で、 eh が適用された goa.Endpoint 型のフィールドを持ちます。
-//
-// この関数は reflect を使用しますが、サーバー起動時にのみ使用され、リクエスト処理時には使用されません。
-// サーバー起動も著しく遅くなることはないので reflect を使っても問題ないと判断しました。
-func ErrorHandledEndpoints[T any](endpoints T, eh func(error) error) T {
-	srcVal := reflect.ValueOf(endpoints).Elem() // ポインタ
-	fmt.Printf("srcVal: [%T] %+v\n", srcVal.Interface(), srcVal.Interface())
-	dstVal := reflect.New(srcVal.Type()).Elem() // 同じ型のstructを作成。New はポインタのValueを返すので Elem を使う
-	fmt.Printf("dstVal: [%T] %+v\n", dstVal.Interface(), dstVal.Interface())
-
-	fieldNum := srcVal.NumField()
-	for i := 0; i < fieldNum; i++ {
-		field := srcVal.Field(i)
-		if field.Kind() != reflect.Func {
-			continue
-		}
-		fv := field.Interface()
-		fn, ok := fv.(goa.Endpoint)
-		if !ok {
-			continue
-		}
-		var dstFunc goa.Endpoint = func(ctx context.Context, req any) (any, error) {
-			r, err := fn(ctx, req)
-			if err != nil {
-				err = eh(err)
-			}
-			return r, err
-		}
-		// dstField := dstVal.FieldByName(field.Name)
-		dstField := dstVal.Field(i)
-		dstField.Set(reflect.ValueOf(dstFunc))
-	}
-
-	return dstVal.Addr().Interface().(T)
+func ErrorHandledEndpoints[T any](ts T, eh func(error) error) T {
+	return goaendpoints.Wrap[T](ts, goaendpoints.ErrorHandler(eh))
 }

--- a/backend/applib/goa/goaext/error_handlers.go
+++ b/backend/applib/goa/goaext/error_handlers.go
@@ -26,3 +26,11 @@ func StderrErrorHandler(err error) error {
 	}
 	return err
 }
+
+func DefaultErrorHandler(logger Logger) func(error) error {
+	if os.Getenv("APP_STAGE") != "local" {
+		return LoggerErrorHandlerFunc(logger)
+	} else {
+		return StderrErrorHandler
+	}
+}

--- a/backend/applib/goa/goasql/connection_endpoint_wrapper.go
+++ b/backend/applib/goa/goasql/connection_endpoint_wrapper.go
@@ -1,0 +1,22 @@
+package goasql
+
+import (
+	"applib/database/sql"
+	"applib/log"
+	"context"
+
+	goa "goa.design/goa/v3/pkg"
+)
+
+func ConnectionEndpointWrapper(logger *log.Logger) func(goa.Endpoint) goa.Endpoint {
+	return func(ep goa.Endpoint) goa.Endpoint {
+		return func(ctx context.Context, req any) (any, error) {
+			db, err := sql.Open(logger)
+			if err != nil {
+				return nil, err
+			}
+			defer db.Close()
+			return ep(sql.NewContextWithConnection(ctx, db), req)
+		}
+	}
+}

--- a/modifiers/backend/apisvr/services/cmd/apisvr/main.go.rb
+++ b/modifiers/backend/apisvr/services/cmd/apisvr/main.go.rb
@@ -1,19 +1,22 @@
 # coding: utf-8
 
-$content.sub!('chatapi "apisvr/services"'){|key| ['"applib/goa/goaext"', "\t"+ key].join("\n") }
+$content.sub!('"context"'){|key| [
+    'goaendpoints "applib/goa/endpoints"',
+	'"applib/goa/goaext"',
+	'"applib/goa/goasql"',
+    key
+].join("\n") }
 $content.sub!('logger = log.New("chatapi", false)'){ 'logger = log.New("chatapi", dbgF != nil && *dbgF)' }
 
 error_handler_def = <<EOS
-        var eh func(err error) error
-        if os.Getenv("APP_STAGE") != "local" {
-            eh = goaext.LoggerErrorHandlerFunc(logger)
-        } else {
-            eh = goaext.StderrErrorHandler
-        }
+        wappers := goaendpoints.Wrappers{
+			goaendpoints.ErrorHandler(goaext.DefaultErrorHandler(logger)),
+			goasql.ConnectionEndpointWrapper(logger.Logger),
+		}
 EOS
 endpoints_cnt = 0
 $content.gsub!(/(\w+)Endpoints = (\w+)\.NewEndpoints\((\w+)\)/) do |m|
-    r = "#{$1}Endpoints = goaext.ErrorHandledEndpoints[*#{$2}.Endpoints](#{$2}.NewEndpoints(#{$3}), eh)"
+    r = "#{$1}Endpoints = goaendpoints.Wrap[*#{$2}.Endpoints](#{$2}.NewEndpoints(#{$3}), wappers.Wrap)"
     r = error_handler_def + r  if endpoints_cnt == 0
     endpoints_cnt += 1
     r


### PR DESCRIPTION
goa の APIKeySecurity を導入するにあたって、実際に認証を行うサービスの  APIKeyAuth メソッドは、サービスのメソッドが呼ばれる前に呼び出されます。APIKeyAuth メソッド でも DB認証を行う場合、既存の仕組みでは APIKeyAuth メソッド と 処理のメソッドそれぞれにDBに接続する必要が発生してしまいます。

これを避けるために これらを呼び出す本となる Endpoint に DB への接続の処理を組み込みます。

具体的には、 backend/apisvr/services/cmd/apisvr/main.go で生成する Endpoints に渡される各メソッドに相当する Endpoint ( = `func(ctx context.Context, request any) (response any, err error)` ) をラップする関数 Wrap を backend/applib/goa/endpoints に追加し、ここに backend/applib/goa/goasql パッケージに追加した ConnectionEndpointWrapper を指定するようにしました（エラーハンドリングの関数も）。

ConnectionEndpointWrapper は リクエストの都度、DBに接続し、そのオブジェクト `*sql.DB` を Context に格納します。
Context への格納と取り出しは backend/applib/database/sql ni追加された `NewContextWithConnection` と `ConnectionFromContext` 関数で行います。

これによって、サービスの  APIKeyAuth メソッド と サービスのメソッド は一つのリクエストの処理において同じDB接続を使用することができます。
